### PR TITLE
Use new signature for CalcWordWrapPosition

### DIFF
--- a/imgui_md.cpp
+++ b/imgui_md.cpp
@@ -445,7 +445,7 @@ void imgui_md::SPAN_DEL(bool e)
 
 void imgui_md::render_text(const char* str, const char* str_end)
 {
-	const float scale = ImGui::GetStyle().FontScaleMain;
+	const float size = get_font().size;
 	const ImGuiStyle& s = ImGui::GetStyle();
 	bool is_lf = false;
 
@@ -464,7 +464,7 @@ void imgui_md::render_text(const char* str, const char* str_end)
 			}
 
 			te = ImGui::GetFont()->CalcWordWrapPosition(
-				scale, str, str_end, wl);
+				size, str, str_end, wl);
 
 			if (te == str)++te;
 		}


### PR DESCRIPTION
See issue [366](https://github.com/pthom/imgui_bundle/issues/366) in the `imgui_bundle` repo for details. The API for `CalcWordWrapPosition` changed and one of the parameters is incorrect in the current imgui_md.

I can't test this locally since I don't have a working build setup for `imgui_bundle` but I think this is all that's needed. 